### PR TITLE
Keep only sha256.js, d.ts, README and LICENSE in NPM pkg.

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.1.0",
   "description": "SHA-256, HMAC and PBKDF2 implementation with typed arrays for modern browsers and Node.js",
   "main": "sha256.js",
+  "files": ["sha256.js", "sha256.d.ts"],
   "typings": "sha256",
   "directories": {
     "test": "test"


### PR DESCRIPTION
There is no reason to keep anything else. It just makes it harder to analyze the package. Folks who need something else should use Git or download files separately.